### PR TITLE
admin/global_exception

### DIFF
--- a/virspit-admin/src/main/java/com/virspit/virspitadmin/error/ErrorCode.java
+++ b/virspit-admin/src/main/java/com/virspit/virspitadmin/error/ErrorCode.java
@@ -1,0 +1,39 @@
+package com.virspit.virspitadmin.error;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT_VALUE( 400, "C001", "Invalid input value"),
+    METHOD_NOT_ALLOWED(405, "C002", "Method not allowed"),
+    ENTITY_NOT_FOUND(400, "C003", "Entity not found"),
+    INTERNAL_SERVER_ERROR(500, "C004", "Server error"),
+    INVALID_TYPE_VALUE(400, "C005", "Invalid type value"),
+    ACCESS_DENIED(403, "C006", "Access is denied"),
+    NO_HANDLER_FOUND(404, "C007", "Not found"),
+
+    // TODO: 각 도메인에서 발생할 오류에 대한 코드 추가
+    // Member
+    EMAIL_DUPLICATION(400, "M001", "Email is Duplication"),
+    LOGIN_INPUT_INVALID(400, "M002", "Login input is invalid"),
+
+    // Coupon
+    COUPON_ALREADY_USE(400, "CO001", "Coupon was already used"),
+    COUPON_EXPIRE(400, "CO002", "Coupon was already expired");
+
+    @Getter
+    private final int status;
+    @Getter
+    private final String code;
+    @Getter
+    private final String message;
+
+    ErrorCode(final int status, final String code, final String message) {
+        this.status = status;
+        this.message = message;
+        this.code = code;
+    }
+}

--- a/virspit-admin/src/main/java/com/virspit/virspitadmin/error/ErrorResponse.java
+++ b/virspit-admin/src/main/java/com/virspit/virspitadmin/error/ErrorResponse.java
@@ -36,7 +36,7 @@ public class ErrorResponse {
         return new ErrorResponse(code, FieldError.of(bindingResult));
     }
 
-    public static ErrorResponse of(final ErrorCode errorCode){
+    public static ErrorResponse of(final ErrorCode errorCode) {
         return new ErrorResponse(errorCode);
     }
 
@@ -70,8 +70,7 @@ public class ErrorResponse {
         }
 
         private static List<FieldError> of(final BindingResult bindingResult) {
-            final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
-            return fieldErrors.stream()
+            return bindingResult.getFieldErrors().stream()
                     .map(error -> new FieldError(
                             error.getField(),
                             error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),

--- a/virspit-admin/src/main/java/com/virspit/virspitadmin/error/ErrorResponse.java
+++ b/virspit-admin/src/main/java/com/virspit/virspitadmin/error/ErrorResponse.java
@@ -1,0 +1,82 @@
+package com.virspit.virspitadmin.error;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+    private String message;
+    private int status;
+    private List<FieldError> errors;
+    private String code;
+
+    private ErrorResponse(final ErrorCode errorCode, final List<FieldError> errors) {
+        message = errorCode.getMessage();
+        status = errorCode.getStatus();
+        code = errorCode.getCode();
+        this.errors = errors;
+    }
+
+    private ErrorResponse(final ErrorCode errorCode) {
+        message = errorCode.getMessage();
+        status = errorCode.getStatus();
+        code = errorCode.getCode();
+        errors = new ArrayList<>();
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+        return new ErrorResponse(code, FieldError.of(bindingResult));
+    }
+
+    public static ErrorResponse of(final ErrorCode errorCode){
+        return new ErrorResponse(errorCode);
+    }
+
+    public static ErrorResponse of(final ErrorCode errorCode, final List<FieldError> errors) {
+        return new ErrorResponse(errorCode, errors);
+    }
+
+    public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
+        final String value = e.getValue() == null ? "" : e.getValue().toString();
+        final List<ErrorResponse.FieldError> errors = ErrorResponse.FieldError.of(e.getName(), value, e.getErrorCode());
+        return new ErrorResponse(ErrorCode.INVALID_TYPE_VALUE, errors);
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+
+        private FieldError(final String field, final String value, final String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+
+        public static List<FieldError> of(final String field, final String value, final String reason) {
+            List<FieldError> fieldErrors = new ArrayList<>();
+            fieldErrors.add(new FieldError(field, value, reason));
+            return fieldErrors;
+        }
+
+        private static List<FieldError> of(final BindingResult bindingResult) {
+            final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(error -> new FieldError(
+                            error.getField(),
+                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/virspit-admin/src/main/java/com/virspit/virspitadmin/error/GlobalControllerExceptionHandler.java
+++ b/virspit-admin/src/main/java/com/virspit/virspitadmin/error/GlobalControllerExceptionHandler.java
@@ -1,0 +1,78 @@
+package com.virspit.virspitadmin.error;
+
+import com.virspit.virspitadmin.error.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+@Slf4j
+public class GlobalControllerExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        log.error("handleMethodArgumentNotValidException", ex);
+        return new ResponseEntity<>(ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, ex.getBindingResult()), status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleNoHandlerFoundException(NoHandlerFoundException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        log.error("handleNoHandlerFoundException", ex);
+        return new ResponseEntity<>(ErrorResponse.of(ErrorCode.NO_HANDLER_FOUND), status);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("handleMethodArgumentTypeMismatchException", e);
+        return new ResponseEntity<>(ErrorResponse.of(e), HttpStatus.BAD_REQUEST);
+    }
+
+   /* @Override
+    protected ResponseEntity<Object> handleTypeMismatch(TypeMismatchException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        log.error("handleTypeMismatchException", ex);
+        return new ResponseEntity<>(ErrorResponse.of(ex), status);
+    }*/
+
+    @Override
+    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        log.error("handleHttpRequestMethodNotSupportedException", ex);
+        return new ResponseEntity<>(ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED), status);
+    }
+
+    /*@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+        return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
+    }*/
+
+    /*@ExceptionHandler(AccessDeniedException.class)
+    protected ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("handleAccessDeniedException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.HANDLE_ACCESS_DENIED);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(ErrorCode.HANDLE_ACCESS_DENIED.getStatus()));
+    }*/
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+        log.error("handleBusinessException", e);
+        final ErrorCode errorCode = e.getErrorCode();
+        return new ResponseEntity<>(ErrorResponse.of(errorCode), HttpStatus.valueOf(errorCode.getStatus()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("handleException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/virspit-admin/src/main/java/com/virspit/virspitadmin/error/exception/BusinessException.java
+++ b/virspit-admin/src/main/java/com/virspit/virspitadmin/error/exception/BusinessException.java
@@ -1,0 +1,23 @@
+package com.virspit.virspitadmin.error.exception;
+
+import com.virspit.virspitadmin.error.ErrorCode;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+}

--- a/virspit-admin/src/main/java/com/virspit/virspitadmin/error/exception/EntityNotFoundException.java
+++ b/virspit-admin/src/main/java/com/virspit/virspitadmin/error/exception/EntityNotFoundException.java
@@ -1,0 +1,11 @@
+package com.virspit.virspitadmin.error.exception;
+
+import com.virspit.virspitadmin.error.ErrorCode;
+import com.virspit.virspitadmin.error.exception.BusinessException;
+
+public class EntityNotFoundException extends BusinessException {
+
+    public EntityNotFoundException(String message) {
+        super(message, ErrorCode.ENTITY_NOT_FOUND);
+    }
+}

--- a/virspit-admin/src/main/java/com/virspit/virspitadmin/error/exception/InvalidValueException.java
+++ b/virspit-admin/src/main/java/com/virspit/virspitadmin/error/exception/InvalidValueException.java
@@ -1,0 +1,14 @@
+package com.virspit.virspitadmin.error.exception;
+
+import com.virspit.virspitadmin.error.ErrorCode;
+
+public class InvalidValueException extends BusinessException {
+
+    public InvalidValueException(String value) {
+        super(value, ErrorCode.INVALID_INPUT_VALUE);
+    }
+
+    public InvalidValueException(String value, ErrorCode errorCode) {
+        super(value, errorCode);
+    }
+}

--- a/virspit-admin/src/main/resources/application.yml
+++ b/virspit-admin/src/main/resources/application.yml
@@ -19,6 +19,10 @@ spring:
     username: root
     password: root
 
+  # 404 not found 예외 핸들링을 위해 넣은 두 옵션. add-mappings: false 시 static resource 불러오지 않는다고 함
+  web.resources.add-mappings: false
+  mvc.throw-exception-if-no-handler-found: true
+
 logging:
   level:
     org.hibernate:


### PR DESCRIPTION
## 내용
<!--
- 기능에 관련 된 맥락을 파악 할 수 있는 스샷이나 슬랙 링크를 첨부해주세요.
- 추가된 기능들의 나열.
- 포인트: 최대한 자세히 쓸 것. 내 코드 보는 사람은 지금 이 도메인 맥락을 모른다고 가정하기
- 코드에 셀프 코멘트를 달아주면 좋음!
-->

### 1. 컨트롤러에서 발생하는 공통 예외 처리를 위한 Handler, Response, Custom exception 추가

참조: <https://cheese10yun.github.io/spring-guide-exception/>

```
+-- error
|   +-- exception
|   |   +-- BusinessException.java
|   |   +-- EntityNotFoundException.java
|   |   +-- InvalidValueException.java
|   +-- ErrorCode.java
|   +-- ErrorResponse.java
|   +-- GlobalControllerExceptionHandler.java
``` 

>**ErrorCode** 
>-> https status, error code, error message를 담는 enum

>**ErrorResponse** 
>-> 클라이언트에게 반환 될 예외에 대한 정보를 담는 class

>**GlobalControllerExceptionHandler**
>-> throw된 예외를 처리할 핸들러 class

**GlobalControllerExceptionHandler**에서 예외 처리를 하도록 구현했습니다.
**ErrorCode**는 **ErrorResponse**를 구성하기 위해 사용되고
클라이언트에게 반환할 예외에 대한 내용은 **ErrorResponse** 객체를 json으로 매핑해 전달합니다. 

>**BusinessException**
>->비즈니스 로직에서 예외 발생 시 throw할 class

>**EntityNotFoundException**
>->요청하는 Entity가 없을 때 throw할 class

>**InvalidValueException**
>->요청 값이 유효하지 않을 때 throw할 class

**exception** 패키지 내부에는 비즈니스 로직에서 예외 발생 시 throw할 
공통적인 exception을 구현한 클래스들을 추가했습니다. 

### 2. appliation.yml 옵션 추가
```yaml
web.resources.add-mappings: false
mvc.throw-exception-if-no-handler-found: true
```

404 not found 예외는 GlobalControllerExceptionHandler에서 처리가 되지 않아
위 두 옵션을 설정해 해결했습니다.
그리고 **web.resources.add-mappings** 옵션을 false로 지정하면 static resource를 자동으로 읽지 않는다고 합니다.
현재 진행하는 프로젝트는 뷰를 다루지 않아 큰 문제는 없을 거라 판단되지만 깔끔한 처리는 아닌 것 같습니다.

## 특별히 봐줬으면 하는 부분
<!-- 셀프 코멘트도 달아주세요! -->
핸들러에 누락된 예외 처리.
404 not found에 관한 exception을 Custom handler에서 처리할 수 있는 다른 방법이 있는지.

## 참고 사항
<!-- PR을 리뷰할 때 중점적으로 리뷰가 필요하거나 참고가 필요한 내용을 적어주세요. -->
개발 진행 중 처리하지 못한 예외 발생 시 업데이트 하도록 하겠습니다.
그리고 도메인에 대한 컨트롤러 작성 후 예외 처리에 관한 테스트도 추가하도록 하겠습니다.